### PR TITLE
feat: add options to enable Kubernetes events collection

### DIFF
--- a/jx-app-datadog/values.schema.json
+++ b/jx-app-datadog/values.schema.json
@@ -21,6 +21,18 @@
               "title": "Activate Datadog Agent log collection?",
               "description": "See https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup"
             },
+            "collectEvents": {
+              "type": "boolean",
+              "default": "true",
+              "title": "Enable collect of kubernetes events?",
+              "description": "See https://docs.datadoghq.com/agent/kubernetes/event_collection/"
+            },
+            "leaderElection": {
+              "type": "boolean",
+              "default": "true",
+              "title": "Enable agents leader election? (needs to be true if events collection is enabled)",
+              "description": "See https://docs.datadoghq.com/agent/kubernetes/event_collection/#leader-election"
+            },
             "site": {
               "type": "string",
               "title": "Which datadog intake site do you want to use?",


### PR DESCRIPTION
With those flags, DataDog agents will elect a leader which will collect Kubernetes events and push them to DataDog backend. That way, we can create alerts based on events, correlate metrics with
events and display them in dashboards.